### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Upload, edit, search, and generate videos from everyone's favorite LLM and [Vide
 
 You'll need to sign up for an account at [Video Jungle](https://app.video-jungle.com/register) in order to use this tool, and add your API key.
 
+[![smithery badge](https://smithery.ai/badge/video-editor-mcp)](https://smithery.ai/server/video-editor-mcp)
 [![PyPI version](https://badge.fury.io/py/video-editor-mcp.svg)](https://badge.fury.io/py/video-editor-mcp)
 
 ## Components
@@ -101,6 +102,14 @@ $ LOAD_PHOTOS_DB=1 uv run video-editor-mcp YOURAPIKEY
 ## Quickstart
 
 ### Install
+
+#### Installing via Smithery
+
+To install Video Editor for Claude Desktop automatically via [Smithery](https://smithery.ai/server/video-editor-mcp):
+
+```bash
+npx -y @smithery/cli install video-editor-mcp --client claude
+```
 
 #### Claude Desktop
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Video Editor for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/video-editor-mcp

Let me know if any tweaks have to be made!